### PR TITLE
feat: 상세 게시글 API 연동, 좋아요 기능 구현 & refactor: 전체 게시글 조회 API 연동 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^4.0.0",
+        "@radix-ui/react-accordion": "^1.2.3",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
@@ -976,6 +977,37 @@
       "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.3.tgz",
+      "integrity": "sha512-RIQ15mrcvqIkDARJeERSuXSry2N8uYnxkdDetpfmalT/+0ntOXLkFOsh9iwlAsCv+qcmhZjbdJogIm6WBa6c4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collapsible": "1.1.3",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.3.tgz",
@@ -1016,6 +1048,36 @@
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-use-previous": "1.1.0",
         "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.3.tgz",
+      "integrity": "sha512-jFSerheto1X03MUC0g6R7LedNW9EEGWdg9W1+MlpkMLwGkgkbUXLPBH/KIuWKXUoeYRVY11llqbTBDzuLg7qrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^4.0.0",
+    "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.6",

--- a/src/app/community/components/comment.tsx
+++ b/src/app/community/components/comment.tsx
@@ -5,24 +5,33 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 
+import { useDetailPostStore } from '@/stores/community';
+
 export default function Comment() {
+  const { comments } = useDetailPostStore();
   const [comment, setComment] = useState('');
 
   const handleComment = () => {
-    setComment("");
-  }
+    setComment('');
+  };
 
   return (
     <div>
-      <Textarea 
-        value={comment} 
-        onChange={(e) => setComment(e.target.value)} 
-        placeholder="댓글을 작성해 주세요." />
-      <Button 
-        onClick={handleComment}
-        className="w-full">댓글 달기</Button>
+      <Textarea value={comment} onChange={(e) => setComment(e.target.value)} placeholder="댓글을 작성해 주세요." />
+      <Button onClick={handleComment} className="w-full">
+        댓글 달기
+      </Button>
 
-      <div>{comment}</div>
+      <div>
+        {comments.map((comment, index) => (
+          <div key={index}>
+            <div>{comment.content}</div>
+            {comment.replies.map((reply, index) => (
+              <div key={index}>{reply.content}</div>
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/community/components/comment.tsx
+++ b/src/app/community/components/comment.tsx
@@ -1,37 +1,45 @@
 'use client';
 
+import '@/assets/styles/community.css';
+
 import { useState } from 'react';
 
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+
+import { usePostComment } from '@/services/community/hooks/useGetPost';
 
 import { useDetailPostStore } from '@/stores/community';
 
 export default function Comment() {
-  const { comments } = useDetailPostStore();
+  const { comments, id } = useDetailPostStore();
   const [comment, setComment] = useState('');
+  const { mutate: postComment } = usePostComment();
 
-  const handleComment = () => {
+  const handleComment = (postId: number, comment: string) => {
+    postComment({ postId, comment });
     setComment('');
   };
 
   return (
     <div>
       <Textarea value={comment} onChange={(e) => setComment(e.target.value)} placeholder="댓글을 작성해 주세요." />
-      <Button onClick={handleComment} className="w-full">
+      <Button onClick={() => handleComment(id, comment)} className="w-full">
         댓글 달기
       </Button>
 
-      <div>
+      <Accordion type="multiple">
         {comments.map((comment, index) => (
-          <div key={index}>
-            <div>{comment.content}</div>
-            {comment.replies.map((reply, index) => (
-              <div key={index}>{reply.content}</div>
-            ))}
-          </div>
+          <AccordionItem key={index} value={index.toString()}>
+            <AccordionTrigger className={comment.replies?.length == 0 ? 'no-arrow' : ''}>
+              {comment.content}
+            </AccordionTrigger>
+            {comment.replies?.length > 0 &&
+              comment.replies.map((reply, index) => <AccordionContent key={index}>{reply.content}</AccordionContent>)}
+          </AccordionItem>
         ))}
-      </div>
+      </Accordion>
     </div>
   );
 }

--- a/src/app/community/components/post-table.tsx
+++ b/src/app/community/components/post-table.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/pagination';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 
-import { useGetPost } from '@/services/community/hooks/useGetPost';
+import { useGetPost, useGetPostDetail } from '@/services/community/hooks/useGetPost';
 
 import { useAllPostStore } from '@/stores/community';
 
@@ -24,15 +24,17 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
   const [page, setPage] = useState(1);
   const router = useRouter();
 
+  const { mutate: getPost } = useGetPost();
+  const { mutate: getPostDetail } = useGetPostDetail();
+
   const filterContents = contents.filter(
     (content) => content.title.includes(searchWord) || content.content.includes(searchWord),
   );
 
-  const goDetailPage = () => {
+  const goDetailPage = (id: number) => {
+    getPostDetail(id);
     router.push('/community/detail');
   };
-
-  const { mutate: getPost } = useGetPost();
 
   useEffect(() => {
     getPost({ sort: sort, page: page - 1 });
@@ -54,7 +56,7 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
 
         <TableBody>
           {filterContents.map((content, index) => (
-            <TableRow key={index} onClick={goDetailPage}>
+            <TableRow key={index} onClick={() => goDetailPage(content.id)}>
               <TableCell>{content.id}</TableCell>
               <TableCell>{content.title}</TableCell>
               <TableCell>{content.content}</TableCell>

--- a/src/app/community/components/post-table.tsx
+++ b/src/app/community/components/post-table.tsx
@@ -17,18 +17,23 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 
 import { useGetPost, useGetPostDetail } from '@/services/community/hooks/useGetPost';
 
-import { useAllPostStore } from '@/stores/community';
+interface PostDto {
+  id: number;
+  title: string;
+  content: string;
+  username: string;
+  createdAt: string;
+}
 
 export default function PostTable({ sort, searchWord }: { sort: string; searchWord: string }) {
-  const { contents, totalPages } = useAllPostStore();
   const [page, setPage] = useState(1);
   const router = useRouter();
 
-  const { mutate: getPost } = useGetPost();
+  const { data: posts } = useGetPost({ sort: sort, page: page - 1 });
   const { mutate: getPostDetail } = useGetPostDetail();
 
-  const filterContents = contents.filter(
-    (content) => content.title.includes(searchWord) || content.content.includes(searchWord),
+  const filterContents = posts?.content.filter(
+    (post: PostDto) => post.title.includes(searchWord) || post.content.includes(searchWord),
   );
 
   const goDetailPage = (id: number) => {
@@ -37,8 +42,8 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
   };
 
   useEffect(() => {
-    getPost({ sort: sort, page: page - 1 });
-  }, [sort, page]);
+    setPage(1);
+  }, [sort]);
 
   return (
     <div>
@@ -55,13 +60,13 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
         </TableHeader>
 
         <TableBody>
-          {filterContents.map((content, index) => (
-            <TableRow key={index} onClick={() => goDetailPage(content.id)}>
-              <TableCell>{content.id}</TableCell>
-              <TableCell>{content.title}</TableCell>
-              <TableCell>{content.content}</TableCell>
-              <TableCell>{content.username}</TableCell>
-              <TableCell>{content.createdAt}</TableCell>
+          {filterContents?.map((post: PostDto) => (
+            <TableRow key={post.id} onClick={() => goDetailPage(post.id)}>
+              <TableCell>{post.id}</TableCell>
+              <TableCell>{post.title}</TableCell>
+              <TableCell>{post.content}</TableCell>
+              <TableCell>{post.username}</TableCell>
+              <TableCell>{post.createdAt}</TableCell>
               <TableCell>좋아요 수</TableCell>
             </TableRow>
           ))}
@@ -78,7 +83,7 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
             ></PaginationPrevious>
           </PaginationItem>
 
-          {[...Array(totalPages)].map((_, index) => (
+          {[...Array(posts?.totalPages)].map((_, index) => (
             <PaginationItem key={index}>
               <PaginationLink onClick={() => setPage(index + 1)} isActive={index + 1 === page}>
                 {index + 1}
@@ -93,7 +98,7 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
           <PaginationItem>
             <PaginationNext
               onClick={() => {
-                if (page < totalPages) setPage(page + 1);
+                if (page < posts?.totalPages) setPage(page + 1);
               }}
             ></PaginationNext>
           </PaginationItem>

--- a/src/app/community/components/post-table.tsx
+++ b/src/app/community/components/post-table.tsx
@@ -15,20 +15,14 @@ import {
 } from '@/components/ui/pagination';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 
+import { useGetPost } from '@/services/community/hooks/useGetPost';
+
 import { useAllPostStore } from '@/stores/community';
 
 export default function PostTable({ sort, searchWord }: { sort: string; searchWord: string }) {
-  const { contents, totalPages, allPost } = useAllPostStore();
+  const { contents, totalPages } = useAllPostStore();
   const [page, setPage] = useState(1);
   const router = useRouter();
-
-  useEffect(() => {
-    allPost(sort, page - 1);
-  }, [page]);
-
-  useEffect(() => {
-    allPost(sort, page - 1);
-  }, [sort]);
 
   const filterContents = contents.filter(
     (content) => content.title.includes(searchWord) || content.content.includes(searchWord),
@@ -37,6 +31,12 @@ export default function PostTable({ sort, searchWord }: { sort: string; searchWo
   const goDetailPage = () => {
     router.push('/community/detail');
   };
+
+  const { mutate: getPost } = useGetPost();
+
+  useEffect(() => {
+    getPost({ sort: sort, page: page - 1 });
+  }, [sort, page]);
 
   return (
     <div>

--- a/src/app/community/detail/page.tsx
+++ b/src/app/community/detail/page.tsx
@@ -2,6 +2,8 @@
 
 import Comment from '../components/comment';
 
+import { useState } from 'react';
+
 import Link from 'next/link';
 
 import { ArrowLeft, Eye, ThumbsDown, ThumbsUp } from 'lucide-react';
@@ -9,10 +11,23 @@ import { ArrowLeft, Eye, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
+import { usePostLike } from '@/services/community/hooks/useGetPost';
+
 import { useDetailPostStore } from '@/stores/community';
 
 export default function detail() {
   const detailPostStore = useDetailPostStore();
+
+  const { mutate: postLike } = usePostLike();
+
+  const [like, setLike] = useState(detailPostStore.likes);
+  const [isLikeClicked, setIsLikeClicked] = useState(false);
+
+  const updateLike = () => {
+    setLike(like + 1);
+    setIsLikeClicked(true);
+    postLike(detailPostStore.id);
+  };
 
   return (
     <div className="space-y-10">
@@ -36,7 +51,7 @@ export default function detail() {
               {detailPostStore.username} {detailPostStore.createdAt}
             </div>
             <div className="space-x-1">
-              <Button className="bg-red-500">
+              <Button onClick={updateLike} className="bg-red-500" disabled={isLikeClicked}>
                 <ThumbsUp />
                 좋아요 {detailPostStore.likes}
               </Button>

--- a/src/app/community/detail/page.tsx
+++ b/src/app/community/detail/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Comment from '../components/comment';
 
 import Link from 'next/link';
@@ -7,7 +9,11 @@ import { ArrowLeft, Eye, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
+import { useDetailPostStore } from '@/stores/community';
+
 export default function detail() {
+  const detailPostStore = useDetailPostStore();
+
   return (
     <div className="space-y-10">
       <Link href="/community" className="flex space-y-1 underline">
@@ -18,19 +24,21 @@ export default function detail() {
         <CardHeader>
           <div className="flex justify-between">
             <div>
-              <CardTitle>제목</CardTitle>
+              <CardTitle>{detailPostStore.title}</CardTitle>
             </div>
             <div className="flex">
               <Eye />
-              조회수
+              조회수 {detailPostStore.views}
             </div>
           </div>
           <div className="flex justify-between">
-            <div>날짜 / 시간</div>
+            <div>
+              {detailPostStore.username} {detailPostStore.createdAt}
+            </div>
             <div className="space-x-1">
               <Button className="bg-red-500">
                 <ThumbsUp />
-                좋아요
+                좋아요 {detailPostStore.likes}
               </Button>
               <Button className="bg-blue-500">
                 <ThumbsDown />
@@ -40,8 +48,7 @@ export default function detail() {
           </div>
         </CardHeader>
         <CardContent>
-          <div>내용</div>
-          <div>댓글,대댓글 기능</div>
+          <div>{detailPostStore.content}</div>
         </CardContent>
         <CardFooter>카드 footer</CardFooter>
       </Card>

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -9,6 +9,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default function community() {
   const [searchWord, setSearchWord] = useState('');
+  const [sort, setSort] = useState('time');
+
   return (
     <div>
       <div className="font-bold">커뮤니티</div>
@@ -17,7 +19,7 @@ export default function community() {
       </div>
 
       <div className="flex justify-between">
-        <Tabs defaultValue="time">
+        <Tabs value={sort} onValueChange={setSort}>
           <TabsList>
             <TabsTrigger value="time">시간순</TabsTrigger>
             <TabsTrigger value="views">조회수</TabsTrigger>
@@ -31,18 +33,7 @@ export default function community() {
           onChange={(e) => setSearchWord(e.target.value)}
         />
       </div>
-
-      <Tabs defaultValue="time">
-        <TabsContent value="time">
-          <PostTable sort="times" searchWord={searchWord} />
-        </TabsContent>
-        <TabsContent value="views">
-          <PostTable sort="views" searchWord={searchWord} />
-        </TabsContent>
-        <TabsContent value="likes">
-          <PostTable sort="likes" searchWord={searchWord} />
-        </TabsContent>
-      </Tabs>
+      <PostTable sort={sort} searchWord={searchWord} />
     </div>
   );
 }

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -21,7 +21,7 @@ export default function community() {
       <div className="flex justify-between">
         <Tabs value={sort} onValueChange={setSort}>
           <TabsList>
-            <TabsTrigger value="time">시간순</TabsTrigger>
+            <TabsTrigger value="time">최신순</TabsTrigger>
             <TabsTrigger value="views">조회수</TabsTrigger>
             <TabsTrigger value="likes">좋아요</TabsTrigger>
           </TabsList>

--- a/src/assets/styles/community.css
+++ b/src/assets/styles/community.css
@@ -1,0 +1,3 @@
+.no-arrow svg {
+  display: none;
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,7 @@ api.interceptors.request.use(
       request.url?.includes('/api/member/signup')
     )
       return request;
+    const tokenStore = useTokenStore.getState();
     const accessToken = tokenStore.accessToken;
     if (accessToken) {
       request.headers['Authorization'] = accessToken;

--- a/src/services/community/api.ts
+++ b/src/services/community/api.ts
@@ -1,0 +1,7 @@
+import { PostDto } from './types';
+
+import api from '@/lib/api';
+
+export const GET_post = async ({ sort, page }: PostDto) => {
+  return await api.get('/api/community/posts', { params: { sort: sort, page: page } });
+};

--- a/src/services/community/api.ts
+++ b/src/services/community/api.ts
@@ -5,3 +5,7 @@ import api from '@/lib/api';
 export const GET_post = async ({ sort, page }: PostDto) => {
   return await api.get('/api/community/posts', { params: { sort: sort, page: page } });
 };
+
+export const GET_postDetail = async (id: number) => {
+  return await api.get(`/api/community/post/${id}`);
+};

--- a/src/services/community/api.ts
+++ b/src/services/community/api.ts
@@ -1,11 +1,21 @@
-import { PostDto } from './types';
+import { PostCommentDto, PostDto } from './types';
 
 import api from '@/lib/api';
 
 export const GET_post = async ({ sort, page }: PostDto) => {
-  return await api.get('/api/community/posts', { params: { sort: sort, page: page } });
+  const response = await api.get('/api/community/posts', { params: { sort: sort, page: page } });
+  return response.data;
 };
 
 export const GET_postDetail = async (id: number) => {
   return await api.get(`/api/community/post/${id}`);
+};
+
+export const POST_comment = async ({ postId, comment }: PostCommentDto) => {
+  console.log('api', postId, comment);
+  return await api.post(`/api/community/comment/${postId}`, { comment });
+};
+
+export const POST_like = async (id: number) => {
+  return await api.post(`api/community/post/like/${id}`);
 };

--- a/src/services/community/hooks/useGetPost.ts
+++ b/src/services/community/hooks/useGetPost.ts
@@ -1,8 +1,8 @@
-import { GET_post } from '../api';
+import { GET_post, GET_postDetail } from '../api';
 
 import { useMutation } from '@tanstack/react-query';
 
-import { useAllPostStore } from '@/stores/community';
+import { useAllPostStore, useDetailPostStore } from '@/stores/community';
 
 export const useGetPost = () => {
   const allPostStore = useAllPostStore();
@@ -12,6 +12,17 @@ export const useGetPost = () => {
     mutationFn: GET_post,
     onSuccess: ({ data }) => {
       allPostStore.updatePost({ contents: data.content, totalPages: data.totalPages });
+    },
+  });
+};
+
+export const useGetPostDetail = () => {
+  const detailPostStore = useDetailPostStore();
+  return useMutation({
+    mutationKey: [GET_postDetail.name],
+    mutationFn: GET_postDetail,
+    onSuccess: ({ data }) => {
+      detailPostStore.updateDetailPost(data);
     },
   });
 };

--- a/src/services/community/hooks/useGetPost.ts
+++ b/src/services/community/hooks/useGetPost.ts
@@ -1,0 +1,17 @@
+import { GET_post } from '../api';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { useAllPostStore } from '@/stores/community';
+
+export const useGetPost = () => {
+  const allPostStore = useAllPostStore();
+
+  return useMutation({
+    mutationKey: [GET_post.name],
+    mutationFn: GET_post,
+    onSuccess: ({ data }) => {
+      allPostStore.updatePost({ contents: data.content, totalPages: data.totalPages });
+    },
+  });
+};

--- a/src/services/community/hooks/useGetPost.ts
+++ b/src/services/community/hooks/useGetPost.ts
@@ -1,18 +1,14 @@
-import { GET_post, GET_postDetail } from '../api';
+import { GET_post, GET_postDetail, POST_comment, POST_like } from '../api';
 
 import { useMutation } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { useAllPostStore, useDetailPostStore } from '@/stores/community';
+import { useDetailPostStore } from '@/stores/community';
 
-export const useGetPost = () => {
-  const allPostStore = useAllPostStore();
-
-  return useMutation({
-    mutationKey: [GET_post.name],
-    mutationFn: GET_post,
-    onSuccess: ({ data }) => {
-      allPostStore.updatePost({ contents: data.content, totalPages: data.totalPages });
-    },
+export const useGetPost = ({ sort, page }: { sort: string; page: number }) => {
+  return useQuery({
+    queryKey: ['posts', sort, page],
+    queryFn: () => GET_post({ sort, page }),
   });
 };
 
@@ -23,6 +19,27 @@ export const useGetPostDetail = () => {
     mutationFn: GET_postDetail,
     onSuccess: ({ data }) => {
       detailPostStore.updateDetailPost(data);
+    },
+  });
+};
+
+export const usePostComment = () => {
+  return useMutation({
+    mutationKey: [POST_comment.name],
+    mutationFn: POST_comment,
+  });
+};
+
+export const usePostLike = () => {
+  const detailPostStore = useDetailPostStore();
+  return useMutation({
+    mutationKey: [POST_like.name],
+    mutationFn: POST_like,
+    onSuccess: () => {
+      detailPostStore.updateDetailPost({
+        ...detailPostStore,
+        likes: detailPostStore.likes + 1,
+      });
     },
   });
 };

--- a/src/services/community/types.ts
+++ b/src/services/community/types.ts
@@ -2,3 +2,8 @@ export interface PostDto {
   sort: string;
   page: number;
 }
+
+export interface PostCommentDto {
+  postId: number;
+  comment: string;
+}

--- a/src/services/community/types.ts
+++ b/src/services/community/types.ts
@@ -1,0 +1,4 @@
+export interface PostDto {
+  sort: string;
+  page: number;
+}

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -24,7 +24,7 @@ export const useTokenStore = create(
       updateToken: (data) => set(data),
       logout: () => {
         set(tokenInitialState);
-        window.location.href = '/login';
+        window.location.href = '/signin';
       },
     }),
     {

--- a/src/stores/community.ts
+++ b/src/stores/community.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
-
-import api from '@/lib/api';
+import { persist } from 'zustand/middleware';
 
 interface Content {
   id: number;
@@ -19,8 +18,49 @@ interface PostActions {
   updatePost: (data: AllPostState) => void;
 }
 
-export const useAllPostStore = create<AllPostState & PostActions>((set, get) => ({
+interface DetailPost {
+  username: string;
+  title: string;
+  content: string;
+  views: number;
+  likes: number;
+  comments: Comment[];
+  createdAt: string;
+}
+
+interface Comment {
+  content: string;
+  replies: Reply[];
+}
+
+interface Reply {
+  content: string;
+}
+
+interface DetailPostActions {
+  updateDetailPost: (data: DetailPost) => void;
+}
+
+export const useAllPostStore = create<AllPostState & PostActions>((set) => ({
   contents: [],
   totalPages: 0,
   updatePost: (data) => set({ contents: data.contents, totalPages: data.totalPages }),
 }));
+
+export const useDetailPostStore = create<DetailPost & DetailPostActions>()(
+  persist(
+    (set) => ({
+      username: '',
+      title: '',
+      content: '',
+      views: 0,
+      likes: 0,
+      comments: [],
+      createdAt: '',
+      updateDetailPost: (data) => set(data),
+    }),
+    {
+      name: 'detailPost',
+    },
+  ),
+);

--- a/src/stores/community.ts
+++ b/src/stores/community.ts
@@ -1,24 +1,8 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-interface Content {
-  id: number;
-  title: string;
-  content: string;
-  username: string;
-  createdAt: string;
-}
-
-interface AllPostState {
-  contents: Content[];
-  totalPages: number;
-}
-
-interface PostActions {
-  updatePost: (data: AllPostState) => void;
-}
-
 interface DetailPost {
+  id: number;
   username: string;
   title: string;
   content: string;
@@ -41,15 +25,10 @@ interface DetailPostActions {
   updateDetailPost: (data: DetailPost) => void;
 }
 
-export const useAllPostStore = create<AllPostState & PostActions>((set) => ({
-  contents: [],
-  totalPages: 0,
-  updatePost: (data) => set({ contents: data.contents, totalPages: data.totalPages }),
-}));
-
 export const useDetailPostStore = create<DetailPost & DetailPostActions>()(
   persist(
     (set) => ({
+      id: 0,
       username: '',
       title: '',
       content: '',

--- a/src/stores/community.ts
+++ b/src/stores/community.ts
@@ -13,27 +13,14 @@ interface Content {
 interface AllPostState {
   contents: Content[];
   totalPages: number;
-  allPost: (sort: string, page: number) => Promise<void>;
 }
 
-export const useAllPostStore = create<AllPostState>((set, get) => ({
+interface PostActions {
+  updatePost: (data: AllPostState) => void;
+}
+
+export const useAllPostStore = create<AllPostState & PostActions>((set, get) => ({
   contents: [],
   totalPages: 0,
-
-  allPost: async (sort, page) => {
-    try {
-      const response = await api.get('/community/posts', {
-        params: {
-          sort: sort,
-          page: page,
-        },
-      });
-      if (JSON.stringify(get().contents) !== JSON.stringify(response.data.content))
-        set({ contents: response.data.content, totalPages: response.data.totalPages });
-      console.log('전체 커뮤니티 게시글', response.data);
-    } catch (error) {
-      console.error('Failed Get All Post: ', error);
-      throw error;
-    }
-  },
+  updatePost: (data) => set({ contents: data.contents, totalPages: data.totalPages }),
 }));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,21 +56,46 @@ export default {
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
   		},
-		  keyframes: {
-			'slide-top-sm': {
-			  from: { transform: 'translateY(0)' },
-			  to: { transform: 'translateY(-4px)' },
-			},
-			'slide-bottom-sm': {
-			  from: { transform: 'translateY(-4px)' },
-			  to: {transform: 'translateY(0)' }
-			},
-			
-		  },
-		  animation: {
-			'slide-top-sm': 'slide-top-sm 0.2s ease-out both',
-			'slide-bottom-sm': 'slide-bottom-sm 0.2s ease-out both',
-		  },
+  		keyframes: {
+  			'slide-top-sm': {
+  				from: {
+  					transform: 'translateY(0)'
+  				},
+  				to: {
+  					transform: 'translateY(-4px)'
+  				}
+  			},
+  			'slide-bottom-sm': {
+  				from: {
+  					transform: 'translateY(-4px)'
+  				},
+  				to: {
+  					transform: 'translateY(0)'
+  				}
+  			},
+  			'accordion-down': {
+  				from: {
+  					height: '0'
+  				},
+  				to: {
+  					height: 'var(--radix-accordion-content-height)'
+  				}
+  			},
+  			'accordion-up': {
+  				from: {
+  					height: 'var(--radix-accordion-content-height)'
+  				},
+  				to: {
+  					height: '0'
+  				}
+  			}
+  		},
+  		animation: {
+  			'slide-top-sm': 'slide-top-sm 0.2s ease-out both',
+  			'slide-bottom-sm': 'slide-bottom-sm 0.2s ease-out both',
+  			'accordion-down': 'accordion-down 0.2s ease-out',
+  			'accordion-up': 'accordion-up 0.2s ease-out'
+  		}
   	}
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
- 컴포넌트 추가
- 상세 게시글 API 연동
- 새로고침 시 데이터 유지
- 좋아요 기능 구현
- 전체 게시글 조회 API 연동 수정(기존의 useMutation에서 useQuery사용으로 수정)